### PR TITLE
Expose deployment environment secrets to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: staging
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,7 @@ jobs:
     if: github.event_name == 'workflow_run' && needs.detect-release.outputs.should_deploy == 'true'
     needs: detect-release
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       packages: write
@@ -159,6 +160,7 @@ jobs:
     name: Manual Deploy
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

- attach the staging deploy job to the `staging` GitHub environment
- attach production deploys to the `production` environment
- attach manual deploys to the selected environment

## Why

The staging migration in run https://github.com/kalink-studio/stephaniegiorgis/actions/runs/25426738098 failed because `DATABASE_URL`, `DATABASE_URL_DIRECT`, `PAYLOAD_SECRET`, and `PAYLOAD_PUBLIC_SERVER_URL` were empty in the job environment. If these are environment-scoped GitHub secrets, the jobs must declare their target environment before `secrets.*` values are available.

## Validation

- inspected failed job logs from run `25426738098`
- confirmed staging cluster did not roll out and remains on image `ghcr.io/kalink-studio/stephaniegiorgis:ca5c049`