### PR TITLE
[codex] Add signed Cloudflare media worker follow-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ S3_BUCKET=stephaniegiorgis-dev
 
 ## Public media delivery
 PUBLIC_MEDIA_ORIGIN_PRODUCTION=https://media.stephaniegiorgis.ch
-PUBLIC_MEDIA_ORIGIN_STAGING=https://media.staging.stephaniegiorgis.ch
+PUBLIC_MEDIA_ORIGIN_STAGING=https://staging-media.stephaniegiorgis.ch
 
 ## Revalidation / integrations
 REVALIDATE_SECRET=replace-with-a-long-random-secret

--- a/cloudflare/media-worker/worker.js
+++ b/cloudflare/media-worker/worker.js
@@ -1,14 +1,158 @@
 const DEFAULT_S3_ENDPOINT = 'https://s3.pub2.infomaniak.cloud';
+const DEFAULT_S3_REGION = 'us-east-1';
+const S3_SERVICE = 's3';
 const ALLOWED_PREFIXES = ['/media/', '/derivatives/'];
+
+const encoder = new TextEncoder();
 
 const trimTrailingSlash = (value) => value.replace(/\/+$/, '');
 
 const getBucket = (hostname, env) => {
-  if (hostname === 'media.staging.stephaniegiorgis.ch') {
+  if (hostname === 'staging-media.stephaniegiorgis.ch') {
     return env.S3_BUCKET_STAGING || env.S3_BUCKET;
   }
 
   return env.S3_BUCKET_PRODUCTION || env.S3_BUCKET;
+};
+
+const encodeRfc3986 = (value) => {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (character) => {
+    return `%${character.charCodeAt(0).toString(16).toUpperCase()}`;
+  });
+};
+
+const encodePathSegment = (segment) => {
+  try {
+    return encodeRfc3986(decodeURIComponent(segment));
+  } catch {
+    return encodeRfc3986(segment);
+  }
+};
+
+const getCanonicalUri = (pathname) => {
+  return pathname.split('/').map(encodePathSegment).join('/');
+};
+
+const getCanonicalQueryString = (url) => {
+  return Array.from(url.searchParams.entries())
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+      if (leftKey === rightKey) {
+        return leftValue.localeCompare(rightValue);
+      }
+
+      return leftKey.localeCompare(rightKey);
+    })
+    .map(([key, value]) => `${encodeRfc3986(key)}=${encodeRfc3986(value)}`)
+    .join('&');
+};
+
+const normalizeHeaderValue = (value) => value.trim().replace(/\s+/g, ' ');
+
+const getCanonicalHeaders = (headers) => {
+  const entries = Array.from(headers.entries())
+    .map(([name, value]) => [name.toLowerCase(), normalizeHeaderValue(value)])
+    .sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+
+  return {
+    canonicalHeaders: entries
+      .map(([name, value]) => `${name}:${value}\n`)
+      .join(''),
+    signedHeaders: entries.map(([name]) => name).join(';'),
+  };
+};
+
+const toHex = (buffer) => {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+const sha256Hex = async (value) => {
+  return toHex(await crypto.subtle.digest('SHA-256', encoder.encode(value)));
+};
+
+const hmac = async (key, value) => {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    key,
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign'],
+  );
+
+  return crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(value));
+};
+
+const getSigningKey = async (secretAccessKey, dateStamp, region) => {
+  const dateKey = await hmac(
+    encoder.encode(`AWS4${secretAccessKey}`),
+    dateStamp,
+  );
+  const dateRegionKey = await hmac(dateKey, region);
+  const dateRegionServiceKey = await hmac(dateRegionKey, S3_SERVICE);
+
+  return hmac(dateRegionServiceKey, 'aws4_request');
+};
+
+const getAmzDates = (date = new Date()) => {
+  const isoDate = date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+
+  return {
+    amzDate: isoDate,
+    dateStamp: isoDate.slice(0, 8),
+  };
+};
+
+const signOriginRequest = async ({ env, headers, method, originUrl }) => {
+  const accessKeyId = env.S3_ACCESS_KEY_ID;
+  const secretAccessKey = env.S3_SECRET_ACCESS_KEY;
+
+  if (!accessKeyId || !secretAccessKey) {
+    return null;
+  }
+
+  const region = env.S3_REGION || DEFAULT_S3_REGION;
+  const { amzDate, dateStamp } = getAmzDates();
+  const credentialScope = `${dateStamp}/${region}/${S3_SERVICE}/aws4_request`;
+
+  headers.set('host', originUrl.host);
+  headers.set('x-amz-content-sha256', 'UNSIGNED-PAYLOAD');
+  headers.set('x-amz-date', amzDate);
+
+  if (env.S3_SESSION_TOKEN) {
+    headers.set('x-amz-security-token', env.S3_SESSION_TOKEN);
+  }
+
+  const { canonicalHeaders, signedHeaders } = getCanonicalHeaders(headers);
+  const canonicalRequest = [
+    method,
+    getCanonicalUri(originUrl.pathname),
+    getCanonicalQueryString(originUrl),
+    canonicalHeaders,
+    signedHeaders,
+    'UNSIGNED-PAYLOAD',
+  ].join('\n');
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    await sha256Hex(canonicalRequest),
+  ].join('\n');
+  const signingKey = await getSigningKey(secretAccessKey, dateStamp, region);
+  const signature = toHex(await hmac(signingKey, stringToSign));
+
+  headers.set(
+    'authorization',
+    [
+      `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}`,
+      `SignedHeaders=${signedHeaders}`,
+      `Signature=${signature}`,
+    ].join(', '),
+  );
+
+  headers.delete('host');
+
+  return headers;
 };
 
 const isAllowedPath = (pathname) => {
@@ -40,13 +184,7 @@ const getCacheControl = (requestUrl) => {
 const buildOriginHeaders = (request) => {
   const headers = new Headers();
 
-  for (const header of [
-    'accept',
-    'accept-encoding',
-    'if-modified-since',
-    'if-none-match',
-    'range',
-  ]) {
+  for (const header of ['if-modified-since', 'if-none-match', 'range']) {
     const value = request.headers.get(header);
 
     if (value) {
@@ -55,6 +193,15 @@ const buildOriginHeaders = (request) => {
   }
 
   return headers;
+};
+
+const canUseWorkerCache = (request) => {
+  return (
+    request.method === 'GET' &&
+    !request.headers.has('range') &&
+    !request.headers.has('if-none-match') &&
+    !request.headers.has('if-modified-since')
+  );
 };
 
 const withResponseHeaders = (response, requestUrl) => {
@@ -72,7 +219,7 @@ const withResponseHeaders = (response, requestUrl) => {
 };
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const requestUrl = new URL(request.url);
 
     if (request.method === 'OPTIONS') {
@@ -101,11 +248,39 @@ export default {
       return new Response('Missing S3 bucket configuration', { status: 500 });
     }
 
-    const response = await fetch(originUrl, {
+    const cacheKey = new Request(request.url, { method: 'GET' });
+    const shouldUseWorkerCache = canUseWorkerCache(request);
+
+    if (shouldUseWorkerCache) {
+      const cachedResponse = await caches.default.match(cacheKey);
+
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+    }
+
+    const originHeaders = await signOriginRequest({
+      env,
       headers: buildOriginHeaders(request),
+      method: request.method,
+      originUrl,
+    });
+
+    if (!originHeaders) {
+      return new Response('Missing S3 signing configuration', { status: 500 });
+    }
+
+    const response = await fetch(originUrl, {
+      headers: originHeaders,
       method: request.method,
     });
 
-    return withResponseHeaders(response, requestUrl);
+    const publicResponse = withResponseHeaders(response, requestUrl);
+
+    if (shouldUseWorkerCache && publicResponse.status === 200) {
+      ctx.waitUntil(caches.default.put(cacheKey, publicResponse.clone()));
+    }
+
+    return publicResponse;
   },
 };

--- a/cloudflare/media-worker/wrangler.toml.example
+++ b/cloudflare/media-worker/wrangler.toml.example
@@ -4,10 +4,15 @@ compatibility_date = "2026-05-06"
 
 routes = [
   { pattern = "media.stephaniegiorgis.ch/*", zone_name = "stephaniegiorgis.ch" },
-  { pattern = "media.staging.stephaniegiorgis.ch/*", zone_name = "stephaniegiorgis.ch" },
+  { pattern = "staging-media.stephaniegiorgis.ch/*", zone_name = "stephaniegiorgis.ch" },
 ]
 
 [vars]
 S3_ENDPOINT = "https://s3.pub2.infomaniak.cloud"
+S3_REGION = "us-east-1"
 S3_BUCKET_PRODUCTION = "replace-with-production-bucket"
 S3_BUCKET_STAGING = "replace-with-staging-bucket"
+
+# Store credentials as Worker secrets, not plain vars:
+#   npx wrangler secret put S3_ACCESS_KEY_ID
+#   npx wrangler secret put S3_SECRET_ACCESS_KEY

--- a/docs/cloudflare-media.md
+++ b/docs/cloudflare-media.md
@@ -12,7 +12,7 @@ Transformations. The Cloudflare account still needs the following manual setup.
   - `www.stephaniegiorgis.ch`
   - `staging.stephaniegiorgis.ch`
   - `media.stephaniegiorgis.ch`
-  - `media.staging.stephaniegiorgis.ch`
+  - `staging-media.stephaniegiorgis.ch`
 - Use Full Strict SSL.
 
 ## Image transformations
@@ -20,7 +20,7 @@ Transformations. The Cloudflare account still needs the following manual setup.
 - Enable Cloudflare Images Transformations for the zone.
 - Allow these remote source origins:
   - `https://media.stephaniegiorgis.ch`
-  - `https://media.staging.stephaniegiorgis.ch`
+  - `https://staging-media.stephaniegiorgis.ch`
 
 ## Cache rules
 
@@ -34,9 +34,19 @@ Transformations. The Cloudflare account still needs the following manual setup.
 Copy `cloudflare/media-worker/wrangler.toml.example` to `wrangler.toml`, fill in
 the production and staging bucket names, then deploy with Wrangler.
 
-The Worker only serves `/media/*` and `/derivatives/*`, forwards range requests
-to Infomaniak S3 at `https://s3.pub2.infomaniak.cloud`, and sets long-lived
-cache headers for versioned media URLs.
+The Worker only serves `/media/*` and `/derivatives/*`, signs origin requests
+to Infomaniak S3 at `https://s3.pub2.infomaniak.cloud`, caches non-range GET
+responses with Cloudflare's Cache API, forwards range requests without Worker
+cache, and sets long-lived cache headers for versioned media URLs.
+
+Set the S3 credentials as Worker secrets:
+
+```bash
+cd cloudflare/media-worker
+npx wrangler secret put S3_ACCESS_KEY_ID
+npx wrangler secret put S3_SECRET_ACCESS_KEY
+npx wrangler deploy
+```
 
 ## Purge token
 
@@ -49,5 +59,5 @@ Expose only the sensitive Cloudflare values through the runtime secret:
 Expose these as plain runtime configuration:
 
 - `PUBLIC_MEDIA_ORIGIN_PRODUCTION=https://media.stephaniegiorgis.ch`
-- `PUBLIC_MEDIA_ORIGIN_STAGING=https://media.staging.stephaniegiorgis.ch`
+- `PUBLIC_MEDIA_ORIGIN_STAGING=https://staging-media.stephaniegiorgis.ch`
 - `CLOUDFLARE_PURGE_ENABLED=true`

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: PUBLIC_MEDIA_ORIGIN_PRODUCTION
               value: "https://media.stephaniegiorgis.ch"
             - name: PUBLIC_MEDIA_ORIGIN_STAGING
-              value: "https://media.staging.stephaniegiorgis.ch"
+              value: "https://staging-media.stephaniegiorgis.ch"
             - name: CLOUDFLARE_ZONE_ID
               valueFrom:
                 secretKeyRef:

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'media.staging.stephaniegiorgis.ch',
+        hostname: 'staging-media.stephaniegiorgis.ch',
       },
     ],
   },

--- a/payload/runtime/helpers.ts
+++ b/payload/runtime/helpers.ts
@@ -120,7 +120,7 @@ const isUploadDocument = (value: unknown): value is UploadDocument => {
 const DEFAULT_S3_PUBLIC_ENDPOINT = 'https://s3.pub2.infomaniak.cloud';
 const DEFAULT_PRODUCTION_MEDIA_ORIGIN = 'https://media.stephaniegiorgis.ch';
 const DEFAULT_STAGING_MEDIA_ORIGIN =
-  'https://media.staging.stephaniegiorgis.ch';
+  'https://staging-media.stephaniegiorgis.ch';
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
@@ -226,6 +226,16 @@ const getUploadPathFromS3Path = (pathname: string) => {
   return null;
 };
 
+const getUploadPathFromPayloadFilePath = (pathname: string) => {
+  const match = pathname.match(/^\/api\/(media|derivatives)\/file\/(.+)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  return `/${match[1]}/${match[2]}`;
+};
+
 const getUploadVersion = (media?: Partial<UploadDocument> | null) => {
   if (!media) {
     return null;
@@ -267,9 +277,24 @@ export function toPublicMediaUrl(
   if (isMediaPath(parsed.pathname)) {
     uploadPath = parsed.pathname;
   } else {
+    uploadPath = getUploadPathFromPayloadFilePath(parsed.pathname);
+
+    if (uploadPath) {
+      const publicServerUrl = normalizeOrigin(
+        process.env.PAYLOAD_PUBLIC_SERVER_URL,
+      );
+
+      if (
+        parsed.origin !== publicMediaOrigin &&
+        parsed.origin !== publicServerUrl
+      ) {
+        uploadPath = null;
+      }
+    }
+
     const s3PublicEndpoint = getS3PublicEndpoint();
 
-    if (parsed.origin === s3PublicEndpoint) {
+    if (!uploadPath && parsed.origin === s3PublicEndpoint) {
       uploadPath = getUploadPathFromS3Path(parsed.pathname);
     }
   }

--- a/tests/media-url.test.ts
+++ b/tests/media-url.test.ts
@@ -40,10 +40,41 @@ test('toPublicMediaUrl leaves unrelated absolute URLs unchanged', () => {
   );
 });
 
+test('toPublicMediaUrl rewrites Payload derivative file URLs to the staging media host', () => {
+  process.env.PAYLOAD_PUBLIC_SERVER_URL = 'https://staging.stephaniegiorgis.ch';
+  process.env.PUBLIC_MEDIA_ORIGIN_STAGING =
+    'https://staging-media.stephaniegiorgis.ch';
+
+  assert.equal(
+    toPublicMediaUrl('/api/derivatives/file/crop.jpg', {
+      id: 1,
+      updatedAt: '2026-05-06T10:00:00.000Z',
+    }),
+    'https://staging-media.stephaniegiorgis.ch/derivatives/crop.jpg?v=2026-05-06T10%3A00%3A00.000Z',
+  );
+});
+
+test('toPublicMediaUrl rewrites absolute Payload media file URLs on the app origin', () => {
+  process.env.PAYLOAD_PUBLIC_SERVER_URL = 'https://staging.stephaniegiorgis.ch';
+  process.env.PUBLIC_MEDIA_ORIGIN_STAGING =
+    'https://staging-media.stephaniegiorgis.ch';
+
+  assert.equal(
+    toPublicMediaUrl(
+      'https://staging.stephaniegiorgis.ch/api/media/file/example.jpg',
+      {
+        id: 1,
+        updatedAt: '2026-05-06T10:00:00.000Z',
+      },
+    ),
+    'https://staging-media.stephaniegiorgis.ch/media/example.jpg?v=2026-05-06T10%3A00%3A00.000Z',
+  );
+});
+
 test('getMediaPurgeUrls includes unversioned and versioned media URLs', () => {
   process.env.PAYLOAD_PUBLIC_SERVER_URL = 'https://staging.stephaniegiorgis.ch';
   process.env.PUBLIC_MEDIA_ORIGIN_STAGING =
-    'https://media.staging.stephaniegiorgis.ch';
+    'https://staging-media.stephaniegiorgis.ch';
   process.env.S3_PUBLIC_ENDPOINT = 'https://s3.pub2.infomaniak.cloud';
   process.env.S3_BUCKET = 'stephaniegiorgis-staging';
 
@@ -54,8 +85,26 @@ test('getMediaPurgeUrls includes unversioned and versioned media URLs', () => {
       url: 'https://s3.pub2.infomaniak.cloud/stephaniegiorgis-staging/derivatives/crop.webp',
     }),
     [
-      'https://media.staging.stephaniegiorgis.ch/derivatives/crop.webp',
-      'https://media.staging.stephaniegiorgis.ch/derivatives/crop.webp?v=2026-05-06T10%3A00%3A00.000Z',
+      'https://staging-media.stephaniegiorgis.ch/derivatives/crop.webp',
+      'https://staging-media.stephaniegiorgis.ch/derivatives/crop.webp?v=2026-05-06T10%3A00%3A00.000Z',
+    ],
+  );
+});
+
+test('getMediaPurgeUrls includes Payload media file URLs rewritten to the media host', () => {
+  process.env.PAYLOAD_PUBLIC_SERVER_URL = 'https://staging.stephaniegiorgis.ch';
+  process.env.PUBLIC_MEDIA_ORIGIN_STAGING =
+    'https://staging-media.stephaniegiorgis.ch';
+
+  assert.deepEqual(
+    getMediaPurgeUrls({
+      id: 1,
+      updatedAt: '2026-05-06T10:00:00.000Z',
+      url: '/api/media/file/example.jpg',
+    }),
+    [
+      'https://staging-media.stephaniegiorgis.ch/media/example.jpg',
+      'https://staging-media.stephaniegiorgis.ch/media/example.jpg?v=2026-05-06T10%3A00%3A00.000Z',
     ],
   );
 });


### PR DESCRIPTION
## Summary
- add SigV4 signing to the Cloudflare media Worker so it can fetch private Infomaniak S3 objects
- support the configured `staging-media.stephaniegiorgis.ch` media hostname and update app/runtime docs/config defaults
- rewrite Payload `/api/media/file/*` and `/api/derivatives/file/*` URLs to public media-host URLs before Cloudflare image transformation
- add Worker Cache API caching for non-range GET media responses while preserving range passthrough

## Validation
- `pnpm run test`
- `kubectl kustomize k8s/overlays/staging`
- `kubectl kustomize k8s/overlays/production`
- live staging curl checks: Worker media URL returns 200, range request returns 206, Cloudflare image transformation from `staging-media` returns 200 with `cf-resized`

## Notes
- `cloudflare/media-worker/wrangler.toml` remains local deploy config and is not committed.
- The Worker code change needs a Wrangler redeploy after merge for Cache API behavior; the already deployed Worker currently verifies signed S3 access.