### PR TITLE
[codex] Add artwork documentation image layout migration

### DIFF
--- a/.changeset/fuzzy-maps-tap.md
+++ b/.changeset/fuzzy-maps-tap.md
@@ -1,0 +1,5 @@
+---
+'stephaniegiorgis': patch
+---
+
+Add a migration for the artwork documentation Image layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+
+- Any pull request aimed for production deployment must contain at least one changeset. A single pull request may contain multiple changesets.

--- a/migrations/20260509_200000_add_artwork_documentation_image_layout.ts
+++ b/migrations/20260509_200000_add_artwork_documentation_image_layout.ts
@@ -1,0 +1,12 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres';
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TYPE "public"."enum_artworks_blocks_doc_grid_layout" ADD VALUE IF NOT EXISTS 'Image' BEFORE 'Grid 1/1';
+    ALTER TYPE "public"."enum__artworks_v_blocks_doc_grid_layout" ADD VALUE IF NOT EXISTS 'Image' BEFORE 'Grid 1/1';
+  `);
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql``);
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -1,6 +1,7 @@
 import * as migration_20260315_131121 from './20260315_131121';
 import * as migration_20260316_121844_add_page_layout_sections from './20260316_121844_add_page_layout_sections';
 import * as migration_20260506_093837_add_caption_image_square_transform from './20260506_093837_add_caption_image_square_transform';
+import * as migration_20260509_200000_add_artwork_documentation_image_layout from './20260509_200000_add_artwork_documentation_image_layout';
 
 export const migrations = [
   {
@@ -17,5 +18,10 @@ export const migrations = [
     up: migration_20260506_093837_add_caption_image_square_transform.up,
     down: migration_20260506_093837_add_caption_image_square_transform.down,
     name: '20260506_093837_add_caption_image_square_transform'
+  },
+  {
+    up: migration_20260509_200000_add_artwork_documentation_image_layout.up,
+    down: migration_20260509_200000_add_artwork_documentation_image_layout.down,
+    name: '20260509_200000_add_artwork_documentation_image_layout',
   },
 ];


### PR DESCRIPTION
## Summary

Adds a Payload/Postgres migration for the artwork documentation `Image` layout.

## Root cause

Production accepts `Image` in the app schema, but the existing Postgres enums for artwork documentation grid layouts were created before that option existed. Saving an artwork with an `Image` documentation section fails with:

```text
invalid input value for enum enum_artworks_blocks_doc_grid_layout: "Image"
invalid input value for enum enum__artworks_v_blocks_doc_grid_layout: "Image"
```

The migration adds `Image` to both the live artwork block enum and the versioned artwork block enum.

## Validation

- Ran Prettier on the touched migration files.
- `pnpm run tsc` and targeted lint/type checks could not complete in this worktree because local dependencies/tools are missing from `node_modules` (`next`, `payload`, `eslint`, shared TS config, etc.).