### PR TITLE
[codex] Fix contact page layout width

### DIFF
--- a/.changeset/fresh-socks-share.md
+++ b/.changeset/fresh-socks-share.md
@@ -1,0 +1,5 @@
+---
+"stephaniegiorgis": patch
+---
+
+Fix contact page layout width and form control sizing.

--- a/app/(frontend)/[slug]/page.tsx
+++ b/app/(frontend)/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 
 import { PageLayoutRenderer } from '@/components/blocks';
+import { Center } from '@/components/center';
 import { getMediaUrl } from '@/payload/runtime';
 import { getPageBySlug } from '@/payload/runtime/queries';
 
@@ -46,6 +47,14 @@ export default async function StandardPage({
 
   if (!page) {
     notFound();
+  }
+
+  if (slug === 'contact') {
+    return (
+      <Center render={<main />} gutters={10}>
+        <PageLayoutRenderer sections={page.layout} centerSections={false} />
+      </Center>
+    );
   }
 
   return (

--- a/components/contact-form/contact-form.css.ts
+++ b/components/contact-form/contact-form.css.ts
@@ -3,13 +3,13 @@ import { style } from '@vanilla-extract/css';
 
 export const contactForm = style({
   inlineSize: '100%',
-  maxInlineSize: '38rem',
 });
 
 export const control = style({
   display: 'block',
   inlineSize: '100%',
-  minBlockSize: sys.spacing[14],
+  minBlockSize: sys.spacing[10],
+  paddingBlock: sys.spacing[4],
 });
 
 export const messageControl = style([


### PR DESCRIPTION
## Summary

- Render the contact CMS page inside the shared centered page shell so its content width matches the header.
- Let the contact form fill its available column instead of stopping at a fixed max width.
- Reduce the contact input height by replacing the oversized spacing token with smaller system spacing values.

## Why

The contact page content did not visually align with the header width, and the form column had unused horizontal space because the form was capped at `38rem`. The text inputs were also growing too tall on desktop due to the previous `sys.spacing[14]` minimum height.

## Validation

- `pnpm run tsc`
- `pnpm run lint` passes with the existing unrelated `@next/next/no-img-element` warning in `components/rich-text/lexical-rich-text.tsx`
- Refreshed `/contact` in the embedded browser and verified the layout visually.