### PR TITLE
[codex] fix audio player width

### DIFF
--- a/.changeset/audio-player-width.md
+++ b/.changeset/audio-player-width.md
@@ -1,0 +1,5 @@
+---
+'stephaniegiorgis': patch
+---
+
+Constrain documentation audio players to the artwork media column width.

--- a/components/media-player/media-player.css.ts
+++ b/components/media-player/media-player.css.ts
@@ -3,7 +3,10 @@ import { createVar, style } from '@vanilla-extract/css';
 export const maxWidthVar = createVar();
 
 export const mediaPlayer = style({
+  width: '100%',
   maxWidth: maxWidthVar,
+  minWidth: 0,
+  boxSizing: 'border-box',
 
   overflow: 'hidden',
 


### PR DESCRIPTION
## Summary

- Constrains media players to fill and shrink within their parent column.
- Adds a patch changeset for the documentation audio layout fix.

## Why

On `artworks/dubblezinning`, the Vidstack audio player could render wider than the documentation image grid because the player had only `max-width: 100%` and no explicit parent-width sizing or shrink behavior.

## Validation

- `pnpm run lint` passed with one existing warning in `components/rich-text/lexical-rich-text.tsx` about `<img>` usage.
- `pnpm run tsc` passed.