### PR TITLE
[codex] fix artwork image width

### DIFF
--- a/.changeset/fix-artwork-image-width.md
+++ b/.changeset/fix-artwork-image-width.md
@@ -1,0 +1,5 @@
+---
+"stephaniegiorgis": patch
+---
+
+Fix single-image artwork documentation layouts filling their available width.

--- a/components/documentation/documentation-renderer.css.ts
+++ b/components/documentation/documentation-renderer.css.ts
@@ -4,12 +4,16 @@ import { recipe } from '@vanilla-extract/recipes';
 
 export const documentationImageItem = style({
   flex: '1 1 100%',
+  width: '100%',
+  minWidth: 0,
 
   cursor: 'pointer',
 });
 
 export const documentationImageFrame = style({
   width: '100%',
+  maxWidth: 'none',
+  maxHeight: 'none',
 });
 
 globalStyle(`${documentationImageFrame} img`, {
@@ -19,7 +23,9 @@ globalStyle(`${documentationImageFrame} img`, {
 
 const baseImageRow = style({
   display: 'flex',
+  alignItems: 'stretch',
   gap: sys.spacing[4],
+  width: '100%',
 });
 
 export const imageRow = recipe({


### PR DESCRIPTION
## What changed

- Let documentation image rows, triggers, and frames fill the available column width.
- Remove the inherited frame max-height cap for documentation images.

## Why

Artwork documentation entries imported from legacy `Slider` slices now use the single-image `Image` layout. On staging, portrait images were constrained by the frame max-height and rendered too small instead of filling the documentation column.

## Validation

- `pnpm run tsc`
- `pnpm run lint` (passes with the existing rich-text `<img>` warning)