### PR TITLE
[codex] Remove Instagram navigation link

### DIFF
--- a/.changeset/remove-instagram-navigation.md
+++ b/.changeset/remove-instagram-navigation.md
@@ -1,0 +1,5 @@
+---
+"stephaniegiorgis": patch
+---
+
+Remove the Instagram link from desktop and mobile navigation.

--- a/components/navigation/main-navigation.tsx
+++ b/components/navigation/main-navigation.tsx
@@ -2,14 +2,13 @@
 
 import {
   Box,
-  Button,
   Cluster,
   Drawer,
   List,
   Stack,
   Text,
 } from '@kalink-ui/seedly-react';
-import { Instagram, Menu, X } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import Link from 'next/link';
 import { useSelectedLayoutSegment } from 'next/navigation';
 import { ReactNode, useState } from 'react';
@@ -127,19 +126,6 @@ export function MainNavigationClient({ items }: MainNavigationProps) {
                             ))}
                           </List.Root>
                         </Stack>
-                        <Center>
-                          <Button
-                            render={
-                              <a href="https://www.instagram.com/stephaniegiorgis" />
-                            }
-                            nativeButton={false}
-                            icon={<Instagram size="20" strokeWidth={1.5} />}
-                            variant="ghost"
-                            tone="neutral"
-                            size="sm"
-                            aria-label="Instagram"
-                          />
-                        </Center>
                       </Stack>
                     </Box>
                   </Drawer.Content>
@@ -156,21 +142,6 @@ export function MainNavigationClient({ items }: MainNavigationProps) {
 
         <Hidden use={Cluster} at="mdDown" spacing={10} align="center">
           {navItems}
-          <Button
-            render={
-              <a
-                href="https://www.instagram.com/stephaniegiorgis"
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            }
-            nativeButton={false}
-            icon={<Instagram size="20" strokeWidth={1.5} />}
-            variant="ghost"
-            tone="neutral"
-            size="sm"
-            aria-label="Instagram"
-          />
         </Hidden>
       </Cluster>
     </Center>


### PR DESCRIPTION
## Summary

Remove the hard-coded Instagram icon link from both the mobile drawer navigation and desktop navigation.

## Impact

The public navigation now only renders the CMS-provided navigation items. A patch changeset is included for the production-targeted PR requirement.

## Validation

- `pnpm run lint` passes with one existing warning in `components/rich-text/lexical-rich-text.tsx` for `@next/next/no-img-element`.