### PR TITLE
[codex] fix documentation image stretch

### DIFF
--- a/.changeset/fix-documentation-image-stretch.md
+++ b/.changeset/fix-documentation-image-stretch.md
@@ -1,0 +1,5 @@
+---
+"stephaniegiorgis": patch
+---
+
+Stretch artwork documentation sections so single-image layouts fill the available column width.

--- a/components/documentation/documentation-renderer.tsx
+++ b/components/documentation/documentation-renderer.tsx
@@ -46,7 +46,7 @@ export function DocumentationRenderer({
   }
 
   return (
-    <Stack spacing={4} {...props}>
+    <Stack spacing={4} align="stretch" {...props}>
       {sections.map((section, sectionIndex) => (
         <DocumentationSectionRenderer
           key={section.id ?? sectionIndex}


### PR DESCRIPTION
## What changed

- Stretch the artwork documentation renderer root so its image-grid child receives the full documentation column width.
- Add a patch changeset for the follow-up layout fix.

## Why

The previous image-width fix made rows and frames fill their parent, but the renderer root still used Seedly Stack's default `align-items: flex-start`. That let single-image documentation grids shrink to the image's intrinsic width on pages like `/artworks/didascalie`.

## Validation

- `pnpm run tsc`
- `pnpm run lint` (passes with the existing rich-text `<img>` warning)