### PR TITLE
fix: scope Docker build secret

### DIFF
--- a/.changeset/docker-build-secret.md
+++ b/.changeset/docker-build-secret.md
@@ -1,0 +1,5 @@
+---
+'stephaniegiorgis': patch
+---
+
+Scope the dummy Payload build secret to the Docker build command.

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,15 +38,14 @@ COPY . .
 
 # Disable telemetry during build
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV PAYLOAD_SECRET=build-time-payload-secret
 
 # Build arguments for environment variables needed at build time
 # ARG NEXT_PUBLIC_API_URL
 # ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
 RUN \
-  if [ -f pnpm-lock.yaml ]; then pnpm build; \
-  elif [ -f package-lock.json ]; then npm run build; \
+  if [ -f pnpm-lock.yaml ]; then PAYLOAD_SECRET=build-time-payload-secret pnpm build; \
+  elif [ -f package-lock.json ]; then PAYLOAD_SECRET=build-time-payload-secret npm run build; \
   else echo "No lockfile found." && exit 1; \
   fi
 


### PR DESCRIPTION
## Summary
- remove the builder-stage ENV PAYLOAD_SECRET from the Dockerfile
- pass the dummy build-time Payload secret only to the build command
- add a patch changeset for the Docker build warning fix

## Verification
- docker buildx build --check .

## Context
Run 25627684645 surfaced Docker BuildKit's SecretsUsedInArgOrEnv warning for Dockerfile line 41. The value is a dummy build-time secret, but keeping it out of ENV avoids persisting it in the image metadata and clears the BuildKit security check.