### PR TITLE
Fix responsive page image sizing and mobile overflow

### DIFF
--- a/.changeset/fresh-points-fix.md
+++ b/.changeset/fresh-points-fix.md
@@ -1,0 +1,5 @@
+---
+'stephaniegiorgis': patch
+---
+
+Use layout-aware image sizes for caption images, generate larger image transform derivatives, and remove mobile horizontal overflow from standard pages.

--- a/components/blocks/block-renderer.tsx
+++ b/components/blocks/block-renderer.tsx
@@ -13,13 +13,18 @@ import { VideoBlockComponent } from './blocks/video-block';
 interface BlockRendererProps {
   blocks: PageBlock[] | null | undefined;
   className?: string;
+  imageSizes?: string;
 }
 
 /**
  * Replacement for Prismic's SliceZone.
  * Maps each Payload block type to its corresponding React component.
  */
-export function BlockRenderer({ blocks, className }: BlockRendererProps) {
+export function BlockRenderer({
+  blocks,
+  className,
+  imageSizes,
+}: BlockRendererProps) {
   if (!blocks || blocks.length === 0) {
     return null;
   }
@@ -27,18 +32,28 @@ export function BlockRenderer({ blocks, className }: BlockRendererProps) {
   return (
     <Stack spacing={8} align="stretch" className={className}>
       {blocks.map((block, index) => (
-        <BlockSwitch key={block.id ?? index} block={block} />
+        <BlockSwitch
+          key={block.id ?? index}
+          block={block}
+          imageSizes={imageSizes}
+        />
       ))}
     </Stack>
   );
 }
 
-function BlockSwitch({ block }: { block: PageBlock }): ReactNode {
+function BlockSwitch({
+  block,
+  imageSizes,
+}: {
+  block: PageBlock;
+  imageSizes?: string;
+}): ReactNode {
   switch (block.blockType) {
     case 'richText':
       return <RichTextBlockComponent block={block} />;
     case 'captionImage':
-      return <CaptionImageBlockComponent block={block} />;
+      return <CaptionImageBlockComponent block={block} sizes={imageSizes} />;
     case 'video':
       return <VideoBlockComponent block={block} />;
     case 'linkList':

--- a/components/blocks/blocks/caption-image-block.tsx
+++ b/components/blocks/blocks/caption-image-block.tsx
@@ -11,15 +11,16 @@ import type { CaptionImageBlock } from '@/payload/runtime/types';
 
 interface Props {
   block: CaptionImageBlock;
+  sizes?: string;
 }
 
-export function CaptionImageBlockComponent({ block }: Props) {
+export function CaptionImageBlockComponent({ block, sizes }: Props) {
   const selectedTransform = getSelectedTransformKey(block.image) ?? undefined;
 
   return (
     <Stack render={<section />} spacing={3} align="stretch">
       {!selectedTransform ? (
-        <PayloadImage media={block.image} />
+        <PayloadImage media={block.image} sizes={sizes} />
       ) : (
         <Frame
           use={PayloadImage}
@@ -34,6 +35,7 @@ export function CaptionImageBlockComponent({ block }: Props) {
               | '16:9'
           }
           cover
+          sizes={sizes}
         />
       )}
       {block.caption && <LexicalRichText content={block.caption} />}

--- a/components/blocks/page-layout-renderer.tsx
+++ b/components/blocks/page-layout-renderer.tsx
@@ -2,7 +2,11 @@ import { Stack } from '@kalink-ui/seedly-react';
 import { clsx } from 'clsx';
 
 import { Center } from '@/components/center';
-import type { PageLayoutSection } from '@/payload/runtime/types';
+import type {
+  PageLayoutRatio,
+  PageLayoutSection,
+  PageLayoutWidth,
+} from '@/payload/runtime/types';
 
 import { BlockRenderer } from './block-renderer';
 import {
@@ -11,6 +15,76 @@ import {
   sectionContent,
   twoColumnLayout,
 } from './page-layout-renderer.css';
+
+const PAGE_SECTION_MAX_WIDTHS: Record<PageLayoutWidth, number | null> = {
+  small: 720,
+  medium: 960,
+  large: 1280,
+  full: null,
+};
+
+const PAGE_SECTION_GUTTERS_PX = 48;
+const PAGE_SECTION_COLUMN_GAP_PX = 24;
+
+const getSectionImageSizes = (width: PageLayoutWidth) => {
+  const maxWidth = PAGE_SECTION_MAX_WIDTHS[width];
+
+  if (!maxWidth) {
+    return `calc(100vw - ${PAGE_SECTION_GUTTERS_PX}px)`;
+  }
+
+  return `(max-width: ${maxWidth + PAGE_SECTION_GUTTERS_PX}px) calc(100vw - ${PAGE_SECTION_GUTTERS_PX}px), ${maxWidth}px`;
+};
+
+const getColumnMaxWidth = (
+  width: PageLayoutWidth,
+  ratio: PageLayoutRatio,
+  column: 'primary' | 'secondary',
+) => {
+  const maxWidth = PAGE_SECTION_MAX_WIDTHS[width];
+
+  if (!maxWidth) {
+    return column === 'primary'
+      ? ratio === '2_3'
+        ? '40vw'
+        : ratio === '3_2'
+          ? '60vw'
+          : '50vw'
+      : ratio === '2_3'
+        ? '60vw'
+        : ratio === '3_2'
+          ? '40vw'
+          : '50vw';
+  }
+
+  const availableWidth = maxWidth - PAGE_SECTION_COLUMN_GAP_PX;
+
+  if (ratio === '1_1') {
+    return `${Math.ceil(availableWidth / 2)}px`;
+  }
+
+  const columnShare =
+    column === 'primary'
+      ? ratio === '3_2'
+        ? 3 / 5
+        : 2 / 5
+      : ratio === '3_2'
+        ? 2 / 5
+        : 3 / 5;
+
+  return `${Math.ceil(availableWidth * columnShare)}px`;
+};
+
+const getColumnImageSizes = (
+  width: PageLayoutWidth,
+  ratio: PageLayoutRatio,
+  column: 'primary' | 'secondary',
+) => {
+  const singleColumnSizes = getSectionImageSizes(width);
+  const columnMaxWidth = getColumnMaxWidth(width, ratio, column);
+
+  return `(max-width: 1023px) ${singleColumnSizes}, ${columnMaxWidth}`;
+};
 
 interface PageLayoutRendererProps {
   sections: PageLayoutSection[] | null | undefined;
@@ -48,13 +122,21 @@ function PageLayoutSectionRenderer({
   sectionData: PageLayoutSection;
 }) {
   if (sectionData.columns === 'two') {
+    const ratio = sectionData.ratio ?? '1_1';
+    const width = sectionData.width ?? 'large';
     const content = (
-      <div className={twoColumnLayout({ ratio: sectionData.ratio ?? '1_1' })}>
+      <div className={twoColumnLayout({ ratio })}>
         <div className={sectionContent}>
-          <BlockRenderer blocks={sectionData.primaryBlocks} />
+          <BlockRenderer
+            blocks={sectionData.primaryBlocks}
+            imageSizes={getColumnImageSizes(width, ratio, 'primary')}
+          />
         </div>
         <div className={sectionContent}>
-          <BlockRenderer blocks={sectionData.secondaryBlocks} />
+          <BlockRenderer
+            blocks={sectionData.secondaryBlocks}
+            imageSizes={getColumnImageSizes(width, ratio, 'secondary')}
+          />
         </div>
       </div>
     );
@@ -76,7 +158,10 @@ function PageLayoutSectionRenderer({
 
   const content = (
     <div className={sectionContent}>
-      <BlockRenderer blocks={sectionData.blocks} />
+      <BlockRenderer
+        blocks={sectionData.blocks}
+        imageSizes={getSectionImageSizes(sectionData.width ?? 'large')}
+      />
     </div>
   );
 

--- a/components/blocks/page-layout-renderer.tsx
+++ b/components/blocks/page-layout-renderer.tsx
@@ -146,11 +146,7 @@ function PageLayoutSectionRenderer({
     }
 
     return (
-      <Center
-        gutters={10}
-        size={sectionData.width ?? 'large'}
-        className={section}
-      >
+      <Center gutters={10} size={sectionData.width ?? 'large'}>
         {content}
       </Center>
     );
@@ -170,11 +166,7 @@ function PageLayoutSectionRenderer({
   }
 
   return (
-    <Center
-      gutters={10}
-      size={sectionData.width ?? 'large'}
-      className={section}
-    >
+    <Center gutters={10} size={sectionData.width ?? 'large'}>
       {content}
     </Center>
   );

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -76,6 +76,12 @@ function getPayloadSecret() {
 const derivatives = createImageTransformDerivativeCollection({
   slug: 'derivatives',
   sourceRelationTo: 'media',
+  upload: {
+    resizeOptions: {
+      width: 1600,
+      withoutEnlargement: true,
+    },
+  },
   admin: {
     hidden: true,
   },


### PR DESCRIPTION
## Summary
- generate larger Payload image transform derivatives for responsive display
- pass layout-aware `sizes` to caption images in standard page layouts
- remove the extra centered-section width that caused mobile horizontal overflow

## Verification
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm run test:unit`

## Notes
- Existing undersized derivatives in Payload should be regenerated after deployment so they pick up the new derivative sizing config.