### PR TITLE
[codex] fix Payload admin media fields

### DIFF
--- a/.changeset/admin-media-fields.md
+++ b/.changeset/admin-media-fields.md
@@ -1,0 +1,5 @@
+---
+"stephaniegiorgis": patch
+---
+
+Fix Payload admin rich text fields with empty Lexical state and make media transform generation resolve stored upload URLs.

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -14,6 +14,7 @@ import { buildConfig } from 'payload';
 import sharp from 'sharp';
 
 import { SeedlyTypographyFeature } from './payload/editor/seedly-typography/server.ts';
+import { getPayloadServerURL } from './payload/runtime/serverUrl.ts';
 import { authenticated, anyone } from './payload/schema/access/index.ts';
 import { Artworks } from './payload/schema/collections/artworks.ts';
 import { Media } from './payload/schema/collections/media.ts';
@@ -93,7 +94,7 @@ const derivatives = createImageTransformDerivativeCollection({
 
 export default buildConfig({
   secret: getPayloadSecret(),
-  serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL,
+  serverURL: getPayloadServerURL(),
   admin: {
     user: Users.slug,
     importMap: {

--- a/payload/runtime/helpers.ts
+++ b/payload/runtime/helpers.ts
@@ -1,3 +1,5 @@
+import { getPayloadServerURL, normalizeOrigin } from './serverUrl';
+
 import type {
   ArtworkDocument,
   ImageTransformValue,
@@ -122,24 +124,12 @@ const DEFAULT_PRODUCTION_MEDIA_ORIGIN = 'https://media.stephaniegiorgis.ch';
 const DEFAULT_STAGING_MEDIA_ORIGIN =
   'https://staging-media.stephaniegiorgis.ch';
 
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
-
-const normalizeOrigin = (value: string | null | undefined) => {
-  if (!value) {
-    return null;
-  }
-
-  try {
-    return new URL(value).origin;
-  } catch {
-    return trimTrailingSlash(value);
-  }
-};
-
 const getRuntimeHostname = () => {
-  if (process.env.PAYLOAD_PUBLIC_SERVER_URL) {
+  const serverURL = getPayloadServerURL();
+
+  if (serverURL) {
     try {
-      return new URL(process.env.PAYLOAD_PUBLIC_SERVER_URL).hostname;
+      return new URL(serverURL).hostname;
     } catch {
       // fall through
     }

--- a/payload/runtime/serverUrl.ts
+++ b/payload/runtime/serverUrl.ts
@@ -1,0 +1,38 @@
+const DEFAULT_PRODUCTION_SERVER_URL = 'https://www.stephaniegiorgis.ch';
+const DEFAULT_STAGING_SERVER_URL = 'https://staging.stephaniegiorgis.ch';
+
+export const normalizeOrigin = (value: string | null | undefined) => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return value.replace(/\/+$/, '');
+  }
+};
+
+export const getPayloadServerURL = () => {
+  const explicitURL = normalizeOrigin(process.env.PAYLOAD_PUBLIC_SERVER_URL);
+
+  if (explicitURL) {
+    return explicitURL;
+  }
+
+  const bucket = process.env.S3_BUCKET ?? '';
+
+  if (bucket.includes('staging')) {
+    return DEFAULT_STAGING_SERVER_URL;
+  }
+
+  if (bucket.includes('production')) {
+    return DEFAULT_PRODUCTION_SERVER_URL;
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    return DEFAULT_PRODUCTION_SERVER_URL;
+  }
+
+  return undefined;
+};

--- a/payload/schema/collections/artworks.ts
+++ b/payload/schema/collections/artworks.ts
@@ -11,6 +11,7 @@ import {
 import { seoField } from '../fields/seo.ts';
 import { getArtworkRevalidationEntries } from '../utils/publicInvalidation.ts';
 import { triggerRevalidation } from '../utils/revalidate.ts';
+import { normalizeEmptyRichText } from '../utils/richText.ts';
 
 import type { CollectionConfig } from 'payload';
 
@@ -42,18 +43,23 @@ export const Artworks: CollectionConfig = {
     },
   },
   hooks: {
+    afterRead: [
+      ({ doc }) => {
+        return normalizeEmptyRichText(doc) ?? doc;
+      },
+    ],
     beforeChange: [
       ({ data }) => {
         if (!data || typeof data !== 'object') {
           return data;
         }
 
-        return {
+        return normalizeEmptyRichText({
           ...data,
           documentationSections: normalizeDocumentationSections(
             data.documentationSections,
           ),
-        };
+        });
       },
     ],
     afterChange: [

--- a/payload/schema/collections/media.ts
+++ b/payload/schema/collections/media.ts
@@ -1,3 +1,4 @@
+import { toPublicMediaUrl } from '../../runtime/helpers.ts';
 import { authenticated, anyone } from '../access/index.ts';
 import {
   purgeUploadAfterChange,
@@ -19,6 +20,18 @@ export const Media: CollectionConfig = {
   },
   upload: true,
   hooks: {
+    afterRead: [
+      ({ doc }) => {
+        if (typeof doc.url !== 'string') {
+          return doc;
+        }
+
+        return {
+          ...doc,
+          url: toPublicMediaUrl(doc.url, doc),
+        };
+      },
+    ],
     afterChange: [purgeUploadAfterChange],
     afterDelete: [purgeUploadAfterDelete],
   },

--- a/payload/schema/collections/pages.ts
+++ b/payload/schema/collections/pages.ts
@@ -4,6 +4,7 @@ import { pageLayoutField } from '../fields/pageLayout.ts';
 import { seoField } from '../fields/seo.ts';
 import { getPageRevalidationEntries } from '../utils/publicInvalidation.ts';
 import { triggerRevalidation } from '../utils/revalidate.ts';
+import { normalizeEmptyRichText } from '../utils/richText.ts';
 
 import type { CollectionConfig } from 'payload';
 
@@ -35,6 +36,16 @@ export const Pages: CollectionConfig = {
     },
   },
   hooks: {
+    afterRead: [
+      ({ doc }) => {
+        return normalizeEmptyRichText(doc) ?? doc;
+      },
+    ],
+    beforeChange: [
+      ({ data }) => {
+        return normalizeEmptyRichText(data) ?? data;
+      },
+    ],
     afterChange: [
       async ({ doc, operation, previousDoc }) => {
         await triggerRevalidation(

--- a/payload/schema/utils/richText.ts
+++ b/payload/schema/utils/richText.ts
@@ -1,0 +1,46 @@
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const isEmptyLexicalRoot = (value: unknown) => {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const root = value.root;
+
+  return (
+    isObject(root) &&
+    root.type === 'root' &&
+    Array.isArray(root.children) &&
+    root.children.length === 0
+  );
+};
+
+export const normalizeEmptyRichText = <T>(value: T): T | null => {
+  if (isEmptyLexicalRoot(value)) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeEmptyRichText(item)) as T;
+  }
+
+  if (!isObject(value)) {
+    return value;
+  }
+
+  let didChange = false;
+  const normalized: Record<string, unknown> = {};
+
+  for (const [key, childValue] of Object.entries(value)) {
+    const nextValue = normalizeEmptyRichText(childValue);
+    normalized[key] = nextValue;
+
+    if (nextValue !== childValue) {
+      didChange = true;
+    }
+  }
+
+  return (didChange ? normalized : value) as T;
+};

--- a/tests/media-url.test.ts
+++ b/tests/media-url.test.ts
@@ -54,6 +54,21 @@ test('toPublicMediaUrl rewrites Payload derivative file URLs to the staging medi
   );
 });
 
+test('toPublicMediaUrl infers production media host from production bucket', () => {
+  delete process.env.PAYLOAD_PUBLIC_SERVER_URL;
+  process.env.PUBLIC_MEDIA_ORIGIN_PRODUCTION =
+    'https://media.stephaniegiorgis.ch';
+  process.env.S3_BUCKET = 'stephaniegiorgis-production';
+
+  assert.equal(
+    toPublicMediaUrl('/api/media/file/example.jpg', {
+      id: 1,
+      updatedAt: '2026-05-06T10:00:00.000Z',
+    }),
+    'https://media.stephaniegiorgis.ch/media/example.jpg?v=2026-05-06T10%3A00%3A00.000Z',
+  );
+});
+
 test('toPublicMediaUrl rewrites absolute Payload media file URLs on the app origin', () => {
   process.env.PAYLOAD_PUBLIC_SERVER_URL = 'https://staging.stephaniegiorgis.ch';
   process.env.PUBLIC_MEDIA_ORIGIN_STAGING =

--- a/tests/rich-text.test.ts
+++ b/tests/rich-text.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeEmptyRichText } from '../payload/schema/utils/richText.ts';
+
+const emptyLexicalValue = {
+  root: {
+    children: [],
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+};
+
+test('normalizeEmptyRichText converts empty Lexical roots to null', () => {
+  assert.equal(normalizeEmptyRichText(emptyLexicalValue), null);
+});
+
+test('normalizeEmptyRichText normalizes nested empty rich text fields', () => {
+  assert.deepEqual(
+    normalizeEmptyRichText({
+      layout: [
+        {
+          blocks: [
+            {
+              blockType: 'linkList',
+              items: [{ description: emptyLexicalValue, label: 'Kalink' }],
+            },
+          ],
+        },
+      ],
+    }),
+    {
+      layout: [
+        {
+          blocks: [
+            {
+              blockType: 'linkList',
+              items: [{ description: null, label: 'Kalink' }],
+            },
+          ],
+        },
+      ],
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fix two Payload admin failures seen while editing content:

- normalize empty Lexical rich text roots to `null` on read and write so optional rich text fields do not mount an invalid empty editor state
- expose public media URLs from media document reads and add a server URL fallback so Canopy image transform generation can resolve upload URLs
- add focused unit coverage for the rich text normalization and production media URL inference paths
- add the required changeset for a production-bound PR

## Root Cause

Optional rich text fields could contain a serialized Lexical root with no children. Lexical rejects that as an empty editor state when Payload admin tries to mount the field.

The image transform flow was also receiving stored Payload upload URLs such as `/api/media/file/...` in a context where Canopy needed an absolute source URL for derivative generation.

## Validation

- `pnpm test`